### PR TITLE
docs: add experimental warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This is an experimental library and not officially supported / endorsed by [bpmn.io](https://bpmn.io/). See also [caveats](#caveats).
+
 # bpmn-js-headless
 
 [![CI](https://github.com/bpmn-io/bpmn-js-headless/actions/workflows/CI.yml/badge.svg)](https://github.com/bpmn-io/bpmn-js-headless/actions/workflows/CI.yml)


### PR DESCRIPTION
This ensures that it is clear for users what to expect from this library.